### PR TITLE
Command Line Functionality

### DIFF
--- a/sims/clean_sim.ipynb
+++ b/sims/clean_sim.ipynb
@@ -2,12 +2,21 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 1,
    "id": "6cef10db-1cf2-4d9a-a56d-9f4eec7f1e5a",
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/anahumr/miniconda3/envs/mxene/lib/python3.12/site-packages/gmso/core/element.py:10: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.\n",
+      "  from pkg_resources import resource_filename\n"
+     ]
+    }
+   ],
    "source": [
     "# import necessary libraries, filter warnings\n",
     "import flowermd\n",
@@ -40,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 2,
    "id": "4bb641a0-5cb8-4843-8f3d-b247cd75a81c",
    "metadata": {
     "scrolled": true
@@ -91,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 3,
    "id": "f0a777f9-bcbd-41b4-8687-0dc45705e2d4",
    "metadata": {},
    "outputs": [],
@@ -127,13 +136,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
    "id": "e9df9bc1-9499-4bc5-843d-209e5c6e2d3d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def run_simulation(N_chains=40, initial_dens=0.001, final_dens=0.3, N_flakes=10, \n",
-    "                   chain_length=10, dt=0.0005, temp=3, device='CPU'):\n",
+    "def run_simulation(N_chains=30, initial_dens=0.001, final_dens=0.3, N_flakes=10, \n",
+    "                   chain_length=10, dt=0.005, temp=3, device='CPU'):\n",
     "    \"\"\"\n",
     "    Runs an entropy-driven aggregation simulation on HOOMD with the specified parameters.\n",
     "\n",
@@ -196,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 5,
    "id": "d484286a-c195-4d1f-9078-1cb5c906ef7c",
    "metadata": {},
    "outputs": [],
@@ -207,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "id": "2e359c9b-5ef4-4703-b5c4-b82ef508efa1",
    "metadata": {},
    "outputs": [],
@@ -236,12 +245,12 @@
     "        ''')\n",
     "    )\n",
     "\n",
-    "    parser.add_argument(\"--N_chains\", type=int, default=40, help=\"Number of polymer chains (default: 40)\")\n",
+    "    parser.add_argument(\"--N_chains\", type=int, default=30, help=\"Number of polymer chains (default: 30)\")\n",
     "    parser.add_argument(\"--initial_dens\", type=float, default=0.001, help=\"Initial density (default: 0.001)\")\n",
     "    parser.add_argument(\"--final_dens\", type=float, default=0.3, help=\"Final density (default: 0.3)\")\n",
     "    parser.add_argument(\"--N_flakes\", type=int, default=10, help=\"Number of flakes (default: 10)\")\n",
     "    parser.add_argument(\"--chain_length\", type=int, default=10, help=\"Length of each chain (default: 10)\")\n",
-    "    parser.add_argument(\"--dt\", type=float, default=0.0005, help=\"Time step (default: 0.0005)\")\n",
+    "    parser.add_argument(\"--dt\", type=float, default=0.005, help=\"Time step (default: 0.005)\")\n",
     "    parser.add_argument(\"--temp\", type=float, default=3, help=\"Simulation temperature (default: 3)\")\n",
     "    parser.add_argument(\"--device\", choices=[\"CPU\", \"GPU\"], default=\"CPU\", help=\"Compute device (default: CPU)\")\n",
     "\n",


### PR DESCRIPTION
Added a code block to clean_sim.ipynb to support command line use of the simulation with args for all sim parameters. _It's important that any direct simulation calls elsewhere in the notebook are commented out before running through the command line_ or both simulations will be run instead of just the one with desired params. 

Note: run_simulation defaults were also changed, so if merged differently, the command line help display might be incorrect.